### PR TITLE
Rename to `@mainmatter/ember-api-actions`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Installation
 
 * `git clone <repository-url>`
-* `cd ember-data-custom-actions`
+* `cd ember-api-actions`
 * `npm install`
 
 ## Linting

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 ```
-ember install ember-data-custom-actions
+ember install @mainmatter/ember-api-actions
 ```
 
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,4 @@
-export async function customAction(record, { method, path, data }) {
+export async function apiAction(record, { method, path, data }) {
   let modelClass = record.constructor;
   let modelName = modelClass.modelName;
   let adapter = record.store.adapterFor(modelName);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-data-custom-actions",
+  "name": "@mainmatter/ember-api-actions",
   "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [

--- a/tests/unit/custom-actions-test.js
+++ b/tests/unit/custom-actions-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { customAction } from 'ember-data-custom-actions';
+import { apiAction } from '@mainmatter/ember-api-actions';
 import { ServerError } from '@ember-data/adapter/error';
 
 module('customAction()', function (hooks) {
@@ -28,7 +28,7 @@ module('customAction()', function (hooks) {
   test('it works', async function (assert) {
     let { user } = await prepare(this);
 
-    let response = await customAction(user, { method: 'POST', path: 'like' });
+    let response = await apiAction(user, { method: 'POST', path: 'like' });
     assert.deepEqual(response, { success: true });
   });
 
@@ -42,7 +42,7 @@ module('customAction()', function (hooks) {
     );
 
     await assert.rejects(
-      customAction(user, { method: 'POST', path: 'like' }),
+      apiAction(user, { method: 'POST', path: 'like' }),
       ServerError
     );
   });


### PR DESCRIPTION
Turns out `ember-custom-actions` is already a thing, and using a similar name might be confusing. `ember-api-actions` is already a thing too, but since we inherited some of the ideas from there it makes sense to reuse that name with the `@mainmatter` prefix.